### PR TITLE
Official copyright and License format (GNU)

### DIFF
--- a/splitpatch.rb
+++ b/splitpatch.rb
@@ -1,26 +1,30 @@
 #!/usr/local/bin/ruby 
 #
-# splitpatch is a simple script to split a patch up into multiple patch files.
-# if the --hunks option is provided on the command line, each hunk gets its
-# own patchfile.
+#   Copyright
 #
-# Copyright (C) 2007, Peter Hutterer <peter@cs.unisa.edu.au>
+#       Copyright (C) 2007 Peter Hutterer <peter@cs.unisa.edu.au>
 #
-# This program is free software; you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation; either version 2, or (at your option)
-# any later version.
+#   License
 #
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+#       This program is free software; you can redistribute it and/or modify
+#       it under the terms of the GNU General Public License as published by
+#       the Free Software Foundation; either version 2 of the License, or
+#       (at your option) any later version.
 #
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#       This program is distributed in the hope that it will be useful,
+#       but WITHOUT ANY WARRANTY; without even the implied warranty of
+#       MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#       GNU General Public License for more details.
 #
-# 
+#       You should have received a copy of the GNU General Public License
+#       along with this program. If not, see <http://www.gnu.org/licenses/>.
+#
+#  Description
+#
+#       Splitpatch is a simple script to split a patch up into
+#       multiple patch files. If the --hunks option is provided on the
+#       command line, each hunk gets its own patchfile.
+
 class Splitter
    def initialize(file)
        @filename = file


### PR DESCRIPTION
Please consider this patch to format the initial comments to show information under specific heading for easy reading. Notes: (a) the official GPL omits address and uses currently only URL (b) there is no comma after year in a copyright year.

Signed-off-by: Jari Aalto jari.aalto@cante.net
