### PR TITLE
Use /usr/bin/env to support non standard ruby locations

### DIFF
--- a/splitpatch.rb
+++ b/splitpatch.rb
@@ -1,4 +1,4 @@
-#!/usr/local/bin/ruby 
+#!/usr/bin/env ruby
 #
 # splitpatch is a simple script to split a patch up into multiple patch files.
 # if the --hunks option is provided on the command line, each hunk gets its


### PR DESCRIPTION
Please consider following patch as suggested in the comment at web page http://www.clearchain.com/blog/posts/splitting-a-patch "As an aside, consider changing the shebang to use ‘env’:
# !/usr/bin/env ruby so that people like me who have ruby in other locations don’t have to modify it."

Signed-off-by: Jari Aalto jari.aalto@cante.net
