### PR TITLE
Use 3 digit zero padded hunk filenames in splitByHunk

### DIFF
--- a/splitpatch.rb
+++ b/splitpatch.rb
@@ -134,7 +134,9 @@ class Splitter
                 if (outfile) 
                     outfile.close_write
                 end
-                hunkfilename = "#{filename}.#{counter}.patch"
+
+                zero = counter.to_s.rjust(3, '0')
+                hunkfilename = "#{filename}.#{zero}.patch"
                 outfile = createFile(hunkfilename)
                 counter += 1
 


### PR DESCRIPTION
This will correct the sort order if over 0..9. Otherwise
files with ls(1) would sort in order: 0, 1, 10 etc.
