### PR TITLE
Make the documentation reproducible

### DIFF
--- a/man/pod2man.mk
+++ b/man/pod2man.mk
@@ -36,7 +36,13 @@ RELEASE         ?= $(PACKAGE)
 
 # Optional variables to set
 MANSECT		?= 1
-PODCENTER	?= $$(date "+%Y-%m-%d")
+
+DATE_FMT = %Y-%m-%d
+ifdef SOURCE_DATE_EPOCH
+PODCENTER	?= $$(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "+$(DATE_FMT)" 2>/dev/null || date -u "+$(DATE_FMT)")
+else
+PODCENTER	?= $$(date "$(DATE_FMT)")
+endif
 
 # Directories
 MANSRC		=


### PR DESCRIPTION
Whilst working on the [Reproducible Builds](https://reproducible-builds.org/) effort, we noticed that splitpatch could not be built reproducibly.

This is because the embedded `pod2man.mk` uses the current build date.